### PR TITLE
Update pngpread.c

### DIFF
--- a/libs/lpng1637/pngpread.c
+++ b/libs/lpng1637/pngpread.c
@@ -223,7 +223,22 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
       if ((png_ptr->mode & PNG_AFTER_IDAT) != 0)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
-
+	
+   else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+	
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)


### PR DESCRIPTION
These commits patch a security vulnerability in libpng described in the following link: https://davidalanreid.github.io/output/347538efbdc21b8df684ebd92d37400b3ce85d55/index.html